### PR TITLE
remove getInstance() calls

### DIFF
--- a/src/main/javascript/Biojs.Protein3D.js
+++ b/src/main/javascript/Biojs.Protein3D.js
@@ -233,7 +233,7 @@ Biojs.Protein3D = Biojs.extend(
 	   Biojs.console.log("registring callback function loadStructCallback " + functionCbName);
 		
 	   // Register the function this._loadStructCallback as global for JmolApplet use 
-	   Biojs.registerGlobal( functionCbName , self._loadStructCallback );
+	   Biojs.registerGlobal( functionCbName , self._loadStructCallback.bind(self) );
 		
 	   // Tell Jmol the name of the function in global scope
 	   jmolSetCallback("loadStructCallback", functionCbName );
@@ -1205,9 +1205,8 @@ Biojs.Protein3D = Biojs.extend(
 		
 		// Ignore the execution of the callback on replacing pdb file.
 		if ( "zapped" != result ) {
-			var instanceId = parseInt( appletId.replace("jmolApplet",'') );
-			var instance = Biojs.getInstance(instanceId);
-	
+     var instance = this;
+
 			if ( "success" == result ) {
 				instance.showControls();
 				instance.displayAntialias(instance.opt.antialias);

--- a/src/main/javascript/Biojs.Protein3DCanvas.js
+++ b/src/main/javascript/Biojs.Protein3DCanvas.js
@@ -215,8 +215,7 @@ Biojs.console.log("executing _loadStructCallback for " + appletId);
 		
 		if ( "zapped" != result ) {
 			//uncover the loading image
-			var instanceId = parseInt( appletId.replace("jmolApplet",'') );
-			var instance = Biojs.getInstance(instanceId);
+     var instance = this;
 			
 			if ( "success" == result ) {
 				instance.displayAntialias(instance.opt.antialias);

--- a/src/main/javascript/Biojs.Table.js
+++ b/src/main/javascript/Biojs.Table.js
@@ -526,7 +526,7 @@ Biojs.Table = Biojs.extend (
     	 // Set URL of the data source
     	 settings.sAjaxSource = this.opt.dataSet.url;
     	 // Set the function which manages the Ajax requests
-    	 settings.fnServerData = this._fetchData;
+    	 settings.fnServerData = this._fetchData.bind(this);
     	 // Enable/disable filtering depending on the support by the server
     	 settings.bFilter = this.opt.dataSet.filter;
      },
@@ -547,9 +547,7 @@ Biojs.Table = Biojs.extend (
     	 var httpRequest = { url: sSource };
     	 var params = aoData;
 
-    	 // Get the Biojs Table instance 
-    	 var biojsId = oSettings.sTableId.substr( "biojs_Table_".length );
-    	 var instance = Biojs.getInstance(biojsId);
+      var instance = this;
 
     	 // Rename param names using those defined in the options instance.opt.dataSet.mapParams
     	 instance._mapUrlParams(aoData);

--- a/src/main/javascript/Biojs.Tooltip.js
+++ b/src/main/javascript/Biojs.Tooltip.js
@@ -273,9 +273,7 @@ Biojs.Tooltip = Biojs.extend (
               // Event triggering 
               self.raiseEvent( Biojs.Tooltip.EVT_ON_SHOW_UP, { 'target': target });
           
-          }).mouseout( function() {
-              timer = setTimeout( 'Biojs.getInstance(' + self.getId()  + ')._hide()' , self.opt.delay );
-          });
+          }).mouseout(hideAfterDelay);
     	  
       } else {
     	  jQuery( targetSelector ).mouseover( function (e) {
@@ -304,21 +302,22 @@ Biojs.Tooltip = Biojs.extend (
               // Event triggering 
               self.raiseEvent( Biojs.Tooltip.EVT_ON_SHOW_UP, { 'target': target });
           
-          }).mouseout( function() {
-              timer = setTimeout( 'Biojs.getInstance(' + self.getId()  + ')._hide()' , self.opt.delay );
-          });
+          }).mouseout(hideAfterDelay);
       }
       
       self._container.mouseover( function(){
           clearTimeout(timer);
-          timer = 0;
           self._show();
       
-      }).mouseout( function() {
-          timer = setTimeout( 'Biojs.getInstance(' + self.getId()  + ')._hide()' , self.opt.delay );
-      });
+      }).mouseout(hideAfterDelay);
       
       this._hide();
+
+      function hideAfterDelay() {
+          timer = setTimeout(function() {
+            self._hide();
+          }, self.opt.delay);
+      }
   },
  
   _hide: function() {

--- a/src/main/javascript/Biojs.js
+++ b/src/main/javascript/Biojs.js
@@ -341,9 +341,6 @@ Biojs.extend = function(_child, _static) { // subclass
 				// Set the unique id for the instance
 				instance.biojsObjectId = Biojs.uniqueId();
 				
-				// register instance
-				Biojs.addInstance(instance);
-				
 				// execute the instance's constructor
 				constructor.apply(instance, arguments);
 				
@@ -674,23 +671,6 @@ Biojs = Biojs.extend({
 	    	Biojs.prototype.__uniqueid = 0;
 	    }
 	    return Biojs.prototype.__uniqueid++;
-	},
-	/**
-     * Register a Biojs instance. 
-     * @type {function}
-     */
-	addInstance: function ( instance ) {
-	    if ( typeof Biojs.prototype.__instances == "undefined" ) {
-	    	Biojs.prototype.__instances = {};
-	    }
-	    return Biojs.prototype.__instances[instance.biojsObjectId] = instance;
-	},
-	/**
-     * Get a Biojs instance by means of its id. 
-     * @type {function}
-     */
-	getInstance: function ( id ) {
-	    return Biojs.prototype.__instances[id];
 	},
 	/**
      * Set a variable in the DOM window. 


### PR DESCRIPTION
- get instance was being used where .bind() should have been
- removing uses of the method allows us to remove it
- removing because it was a memory leak
