### PR TITLE
bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "biojs",
+  "version": "2.0.0",
+  "homepage": "https://github.com/biojs/biojs",
+  "authors": [
+    "\"\""
+  ],
+  "description": "core for the bio-js family of biological visualizations, with legacy support for biojs 1 components",
+  "main": "src/main/javascript/Biojs.js",
+  "keywords": [
+    "biojs",
+    "biology",
+    "biological",
+    "genes",
+    "dna",
+    "visualizations"
+  ],
+  "license": "apache-2",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
As this a mostly front end tool it would be great to add support for bower.io, meaning users can install bio-js to their project with:
`bower install biojs/biojs --save`
(if the pull request is accepted and biojs is registered on the bower servers (much like npm's system) it can be shortened to just:
`bower install biojs --save`

The trend in component management has pushed NPM into use for back end (server side) components and BOWER for front end (client side).
